### PR TITLE
Add WorkQueue metrics to library and dashboard

### DIFF
--- a/dashboards/icinga2.erb
+++ b/dashboards/icinga2.erb
@@ -18,7 +18,7 @@ $(function() {
       <div data-id="icinga-service-meter" data-view="Meter" data-title="Service Problems" data-min="0" data-max="100" style="background-color: #0095bf"></div>
     </li>
     <li data-row="1" data-col="3" data-sizex="1" data-sizey="1">
-      <div data-id="icinga-checks" data-view="List" data-unordered="true" data-title="Checks (1 min)" style="background-color: #0095bf;"></div>
+      <div data-id="icinga-stats" data-view="List" data-unordered="true" data-title="Stats" style="background-color: #0095bf;"></div>
     </li>
     <li data-row="1" data-col="4" data-sizex="1" data-sizey="1">
       <div data-id="icinga-severity" data-view="List" data-unordered="true" data-title="Problems" style="background-color: #0095bf;"></div>

--- a/jobs/icinga2.rb
+++ b/jobs/icinga2.rb
@@ -38,14 +38,19 @@ SCHEDULER.every '5s', :first_in => 0 do |job|
 
   puts "Meter widget: Hosts " + host_meter.to_s + "/" + host_meter_max.to_s + " Services " + service_meter.to_s + "/" + service_meter_max.to_s
 
-  # check stats
-  check_stats = [
-    {"label" => "Host (active)", "value" => icinga.host_active_checks_1min},
-    #{"label" => "Host (passive)", "value" => icinga.host_passive_checks_1min},
-    {"label" => "Service (active)", "value" => icinga.service_active_checks_1min},
-    #{"label" => "Service (passive)", "value" => icinga.service_passive_checks_1min},
+  # icinga stats
+  icinga_stats = [
+    {"label" => "Host checks/min", "value" => icinga.host_active_checks_1min},
+    {"label" => "Service checks/min", "value" => icinga.service_active_checks_1min},
   ]
-  puts "Checks: " + check_stats.to_s
+
+  wqStats = icinga.getWQStats()
+
+  wqStats.each do |name, value|
+    icinga_stats.push( { "label" => name, "value" => "%0.2f" % value } )
+  end
+
+  puts "Stats: " + icinga_stats.to_s
 
   # severity list
   severity_stats = []
@@ -68,8 +73,8 @@ SCHEDULER.every '5s', :first_in => 0 do |job|
    moreinfo: "Total services: " + service_meter_max.to_s,
    color: 'blue' })
 
-  send_event('icinga-checks', {
-   items: check_stats,
+  send_event('icinga-stats', {
+   items: icinga_stats,
    moreinfo: "Avg latency: " + icinga.avg_latency.to_s + "s",
    color: 'blue' })
 


### PR DESCRIPTION
Requires v2.7 or snapshot packages. Won't show any
additional data if keys don't exist in /v1/status