### PR TITLE
Problem dashboards should show unhandled counts (and overall counts below)

### DIFF
--- a/dashboards/icinga2.erb
+++ b/dashboards/icinga2.erb
@@ -26,16 +26,16 @@ $(function() {
 
     <!-- Down, Critical, Warning, Unknown -->
     <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
-      <div data-id="icinga-host-down" data-view="Simplemon" data-title="Hosts Down"></div>
+      <div data-id="icinga-host-problems-down" data-view="Simplemon" data-title="Down Host Problems"></div>
     </li>
     <li data-row="2" data-col="2" data-sizex="1" data-sizey="1">
-      <div data-id="icinga-service-critical" data-view="Simplemon" data-title="Services Critical"></div>
+      <div data-id="icinga-service-problems-critical" data-view="Simplemon" data-title="Critical Service Problems"></div>
     </li>
     <li data-row="2" data-col="3" data-sizex="1" data-sizey="1">
-      <div data-id="icinga-service-warning" data-view="Simplemon" data-title="Services Warning"></div>
+      <div data-id="icinga-service-problems-warning" data-view="Simplemon" data-title="Warning Service Problems"></div>
     </li>
     <li data-row="2" data-col="4" data-sizex="1" data-sizey="1">
-      <div data-id="icinga-service-unknown" data-view="Simplemon" data-title="Services Unknown"></div>
+      <div data-id="icinga-service-problems-unknown" data-view="Simplemon" data-title="Unknown Service Problems"></div>
     </li>
 
     <!-- Acknowledged -->

--- a/jobs/icinga2.rb
+++ b/jobs/icinga2.rb
@@ -27,7 +27,7 @@ SCHEDULER.every '5s', :first_in => 0 do |job|
   icinga.run
 
   puts "App Info: " + icinga.app_data.to_s
-  puts "CIB Info: " + icinga.cib_data.to_s
+  #puts "CIB Info: " + icinga.cib_data.to_s
 
   # meter widget
   # we'll update the patched meter widget with absolute values (set max dynamically)
@@ -83,35 +83,47 @@ SCHEDULER.every '5s', :first_in => 0 do |job|
    color: 'blue' })
 
   # down, critical, warning, unknown
-  send_event('icinga-host-down', {
-   value: icinga.host_count_down.to_s,
+  puts "Host Down: " + icinga.host_count_problems_down.to_s
+  send_event('icinga-host-problems-down', {
+   value: icinga.host_count_problems_down.to_s,
+   moreinfo: "All: " + icinga.host_count_down.to_s,
    color: 'red' })
 
-  send_event('icinga-service-critical', {
-   value: icinga.service_count_critical.to_s,
+  puts "Service Critical: " + icinga.service_count_problems_critical.to_s
+  send_event('icinga-service-problems-critical', {
+   value: icinga.service_count_problems_critical.to_s,
+   moreinfo: "All: " + icinga.service_count_critical.to_s,
    color: 'red' })
 
-  send_event('icinga-service-warning', {
-   value: icinga.service_count_warning.to_s,
+  puts "Service Warning: " + icinga.service_count_problems_warning.to_s
+  send_event('icinga-service-problems-warning', {
+   value: icinga.service_count_problems_warning.to_s,
+   moreinfo: "All: " + icinga.service_count_warning.to_s,
    color: 'yellow' })
 
-  send_event('icinga-service-unknown', {
-   value: icinga.service_count_unknown.to_s,
+  puts "Service Unknown: " + icinga.service_count_problems_unknown.to_s
+  send_event('icinga-service-problems-unknown', {
+   value: icinga.service_count_problems_unknown.to_s,
+   moreinfo: "All: " + icinga.service_count_unknown.to_s,
    color: 'purple' })
 
   # ack, downtime
+  puts "Service Acknowledged: " + icinga.service_count_acknowledged.to_s
   send_event('icinga-service-ack', {
    value: icinga.service_count_acknowledged.to_s,
    color: 'blue' })
 
+  puts "Host Acknowledged: " + icinga.host_count_acknowledged.to_s
   send_event('icinga-host-ack', {
    value: icinga.host_count_acknowledged.to_s,
    color: 'blue' })
 
+  puts "Service In Downtime: " + icinga.service_count_in_downtime.to_s
   send_event('icinga-service-downtime', {
    value: icinga.service_count_in_downtime.to_s,
    color: 'orange' })
 
+  puts "Host In Downtime: " + icinga.host_count_in_downtime.to_s
   send_event('icinga-host-downtime', {
    value: icinga.host_count_in_downtime.to_s,
    color: 'orange' })

--- a/lib/icinga2.rb
+++ b/lib/icinga2.rb
@@ -44,6 +44,7 @@ class Icinga2
   # host stats
   attr_reader :host_count_all
   attr_reader :host_count_problems
+  attr_reader :host_count_problems_down
   attr_reader :host_count_up
   attr_reader :host_count_down
   attr_reader :host_count_in_downtime
@@ -52,6 +53,9 @@ class Icinga2
   # service stats
   attr_reader :service_count_all
   attr_reader :service_count_problems
+  attr_reader :service_count_problems_warning
+  attr_reader :service_count_problems_critical
+  attr_reader :service_count_problems_unknown
   attr_reader :service_count_ok
   attr_reader :service_count_warning
   attr_reader :service_count_critical
@@ -235,6 +239,20 @@ class Icinga2
   def formatService(name)
     service_map = name.split('!', 2)
     return service_map[0].to_s + " - " + service_map[1].to_s
+  end
+
+  def stateFromString(stateStr)
+    if (stateStr == "Down" or stateStr == "Warning")
+      return 1
+    elif (stateStr == "Up" or stateStr == "OK")
+      return 0
+    elif (stateStr == "Critical")
+      return 2
+    elif (stateStr == "Unknown")
+      return 3
+    end
+
+    return "Undefined state. Programming error."
   end
 
   def stateToString(state, is_host = false)
@@ -508,6 +526,8 @@ class Icinga2
 
     @host_count_all = all_hosts_data.size
     @host_count_problems = countProblems(all_hosts_data)
+    @host_count_problems_down = countProblems(all_hosts_data, 1)
+
     @host_count_up = cib_data["num_hosts_up"].to_int
     @host_count_down = cib_data["num_hosts_down"].to_int
     @host_count_in_downtime = cib_data["num_hosts_in_downtime"].to_int
@@ -515,6 +535,10 @@ class Icinga2
 
     @service_count_all = all_services_data.size
     @service_count_problems = countProblems(all_services_data)
+    @service_count_problems_warning = countProblems(all_services_data, 1)
+    @service_count_problems_critical = countProblems(all_services_data, 2)
+    @service_count_problems_unknown = countProblems(all_services_data, 3)
+
     @service_count_ok = cib_data["num_services_ok"].to_int
     @service_count_warning = cib_data["num_services_warning"].to_int
     @service_count_critical = cib_data["num_services_critical"].to_int

--- a/lib/icinga2.rb
+++ b/lib/icinga2.rb
@@ -273,8 +273,18 @@ class Icinga2
     return "Undefined state. Programming error."
   end
 
-  def countProblems(objects)
+  def countProblems(objects, states = nil)
     problems = 0
+
+    compStates = []
+
+    if not states
+      compStates = [ 1, 2, 3]
+    end
+
+    if states.is_a?(Integer)
+      compStates.push(states)
+    end
 
     objects.each do |item|
       item.each do |k, d|
@@ -282,7 +292,7 @@ class Icinga2
           next
         end
 
-        if (d["state"] != 0 && d["downtime_depth"] == 0 && d["acknowledgement"] == 0)
+        if (compStates.include?(d["state"]) && d["downtime_depth"] == 0 && d["acknowledgement"] == 0)
           problems = problems + 1
         end
       end


### PR DESCRIPTION
This also fixes the weird difference between the 'Meter' widget counts
and summary of all problems.

Requested here: https://monitoring-portal.org/index.php?thread/40796-icinga-2-login-mit-dashing-anbinden/

refs #18
fixes #17