### PR TITLE
Move Logo

### DIFF
--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -48,6 +48,7 @@ body {
   font-size: 20px;
   color: $text-color;
   font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+  text-align: center;
 }
 
 b, strong {
@@ -108,6 +109,11 @@ h3 {
   font-size: 25px;
   font-weight: 600;
   color: $text-color;
+}
+
+#banner {
+  text-align: left;
+  padding: 10px;
 }
 
 // ----------------------------------------------------------------------------
@@ -246,8 +252,7 @@ h3 {
 }
 
 #container {
-  //padding-top: 5px;
-  //if background-color is not white there's a nasty white line with padding-top
+  display: inline-block;
 }
 
 

--- a/dashboards/layout.erb
+++ b/dashboards/layout.erb
@@ -18,9 +18,9 @@
 </head>
   <body>
     <div id="container">
-      <div id="banner" style="background-color: #0095bf; padding: 10px">
-        <img src="/assets/logo_icinga-inv.png" style="height: 50px"></img>
-      <div>
+      <div id="banner">
+        <img src="/assets/logo_icinga-inv.png">
+      </div>
       <%= yield %>
     </div>
   


### PR DESCRIPTION
The icinga logo masthead looked a bit inconsistent when floating around separated
from the actual grid.  I've moved it so it is relative to the top left hand corner
of the grid.  Requires #38 so the style doesn't get broken (e.g. requires the
background-color of the body not to be set to white.