### PR TITLE
Allow Overriding of TLS Cert Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ will be used.
 
 If you prefer to use client certificates, set `pki_path` accordingly. The Icinga 2
 job expects the certificate file names based on the local FQDN e.g. `pki/icinga2-master1.localdomain.crt`.
+You can override this behaviour by specifying the `node_name` configuration option
+explicitly.
 
 Note: If both methods are configured, the Icinga 2 job prefers client certificates.
 

--- a/lib/icinga2.rb
+++ b/lib/icinga2.rb
@@ -92,6 +92,7 @@ class Icinga2
         @user = @config["icinga2"]["api"]["user"]
         @password = @config["icinga2"]["api"]["password"]
         @pkiPath = @config["icinga2"]["api"]["pki_path"]
+        @nodeName = @config['icinga2']['api']['node_name']
       else
         @log.warn(sprintf('Config file %s not found! Using default config.', configFile))
         @host = "localhost"
@@ -99,6 +100,7 @@ class Icinga2
         @user = "dashing"
         @password = "icinga2ondashingr0xx"
         @pkiPath = "pki/"
+        @nodeName = nil
       end
 
       @apiVersion = "v1" # TODO: allow user to configure version?
@@ -126,11 +128,13 @@ class Icinga2
   end
 
   def checkCert()
-    begin
-      @nodeName = Socket.gethostbyname(Socket.gethostname).first
-      @log.debug(sprintf('node name: %s', @nodeName))
-    rescue SocketError => error
-      @log.error(error)
+    unless @nodeName
+      begin
+        @nodeName = Socket.gethostbyname(Socket.gethostname).first
+        @log.debug(sprintf('node name: %s', @nodeName))
+      rescue SocketError => error
+        @log.error(error)
+      end
     end
 
     if File.file?(sprintf('%s/%s.crt', @pkiPath, @nodeName))


### PR DESCRIPTION
Currently this defaults to looking for a certificate with the FQDN as
its name.  This adds in an override mechanism so I (anyone) can use
whatever they want, for example I use my client cert whose CN is my
email address.