### PR TITLE
Fix version dependencies in Gemfile for dashing and rack-test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,15 @@
 source 'https://rubygems.org'
 
-gem 'dashing'
+# force the most recent dashing version to avoid #48
+gem 'dashing', '>= 1.3.7'
+
+# dashing server
 gem 'thin'
 gem 'eventmachine'
 
+# sinatra pulls rack-protection which pulls rack-test >= 0. v0.8.0 requires Ruby >= 2.2.2 (this fails on RHEL7).
+gem 'rack-test', '< 0.8.0'
+
+# Icinga 2 job
 gem 'rest-client'
 gem 'json'


### PR DESCRIPTION
fixes #48

Also fixes the new problem on CentOS/RHEL 7 with a new release of
rack-test now requiring Ruby 2.2.2. This is a recursive dependency
of rack-protection pulled from sinatra pulled from dashing.

rack-protection requires rack-test >= 0.

This fails:

```
Gem::InstallError: rack-test requires Ruby version >= 2.2.2.
```