### PR TITLE
Allow to configure the Icinga Web 2 Iframe URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ In case you want to use client certificates, set the `client_cn` accordingly.
 Copy the example configuration from `config/icinga2.json` into `config/icinga2.local.json`
 and adjust the settings for the Icinga 2 API credentials.
 
+The `icingaweb2` section allows you to specify the Icinga Web 2 URL
+for the iframe widgets. This is read on startup once.
+
 ```
 cp config/icinga2.json config/icinga2.local.json
 ```
@@ -196,6 +199,9 @@ vim config/icinga2.local.json
       "user": "dashing",
       "password": "icinga2ondashingr0xx"
     }
+  },
+  "icingaweb2": {
+    "url": "http://localhost/icingaweb2"
   }
 }
 ```
@@ -214,6 +220,9 @@ explicitly.
       "user": "dashing",
       "pki_path": "pki/"
     }
+  },
+  "icingaweb2": {
+    "url": "http://localhost/icingaweb2"
   }
 }
 ```
@@ -238,6 +247,7 @@ ICINGA2\_API\_USERNAME   | **Optional.** Required for basic auth as username.
 ICINGA2\_API\_PASSWORD   | **Optional.** Required for basic auth as password.
 ICINGA2\_API\_CERT\_PATH | **Optional.** Client certificate path.
 ICINGA2\_API\_NODENAME   | **Optional.** If client certificates do not match the host name, override it.
+ICINGAWEB2\_URL          | **Optional.** Set the Icinga Web 2 Url. Defaults to `http://localhost/icingaweb2`.
 
 > **Note**
 >

--- a/config.ru
+++ b/config.ru
@@ -1,4 +1,5 @@
 require 'dashing'
+require './lib/icinga2'
 
 configure do
   set :auth_token, 'YOUR_AUTH_TOKEN'
@@ -13,6 +14,19 @@ configure do
     def protected!
      # Put any authentication code you want in here.
      # This method is run before accessing any resource.
+    end
+
+    # Specify Icinga Web 2 URL
+    # https://github.com/Shopify/dashing/issues/509
+    def getIcingaWeb2Url()
+      # read configuration and try to fetch the correct path
+      icinga = Icinga2.new('config/icinga2.json') # fixed path
+
+      if icinga.icingaweb2_url != nil
+        return icinga.icingaweb2_url
+      else
+        return 'http://192.168.33.5/icingaweb2'
+      end
     end
   end
 end

--- a/config/icinga2.json
+++ b/config/icinga2.json
@@ -6,5 +6,8 @@
       "user": "dashing",
       "password": "icinga2ondashingr0xx"
     }
+  },
+  "icingaweb2": {
+    "url": "http://localhost/icingaweb2"
   }
 }

--- a/dashboards/icinga2.erb
+++ b/dashboards/icinga2.erb
@@ -44,12 +44,12 @@ $(function() {
       <div data-id="icinga-severity" data-view="List" data-unordered="true" data-title="Problems" style="background-color: #0095bf;"></div>
     </li>
 
-    <!-- Icinga Web 2 iFrame -->
+    <!-- Icinga Web 2 iFrame. getIcingaWeb2Url() is defined in config.ru and reads from config/icinga2*.json -->
     <li data-row="3" data-col="1" data-sizex="2" data-sizey="2">
-      <div data-id="iframe" data-view="Iframe" data-url="http://192.168.33.5/icingaweb2/monitoring/list/hosts?host_problem=1&sort=host_severity&showFullscreen&showCompact"></div>
+      <div data-id="iframe" data-view="Iframe" data-url="<%=getIcingaWeb2Url()%>/monitoring/list/hosts?host_problem=1&sort=host_severity&showFullscreen&showCompact"></div>
     </li>
     <li data-row="3" data-col="3" data-sizex="2" data-sizey="2">
-      <div data-id="iframe" data-view="Iframe" data-url="http://192.168.33.5/icingaweb2/monitoring/list/services?service_problem=1&sort=service_severity&dir=desc&showFullscreen&showCompact"></div>
+      <div data-id="iframe" data-view="Iframe" data-url="<%=getIcingaWeb2Url()%>/monitoring/list/services?service_problem=1&sort=service_severity&dir=desc&showFullscreen&showCompact"></div>
     </li>
   </ul>
 


### PR DESCRIPTION
This is a little brainfuck, as we need to create
an instance of the icinga2 class for reading the configuration
details in `config.ru`.

We'll expose the setting inside a helper function, which is
called inside the HTML erb template for the dashboard.

Note: This is done every time the user presses refresh. Job execution
won't trigger this. The previous attempt with updating this on send_event
caused flickering.