### PR TITLE
Update dashing-icinga2

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,17 @@ Install the provided Systemd service file from `tools/systemd`. It assumes
 that the working directory is `/usr/share/dashing-icinga2` and the Dashing gem
 is installed to `/usr/local/bin/dashing`. Adopt these paths for your own needs.
 
+#### Redhat/CentOS
 ```
 cp tools/systemd/dashing-icinga2.service /usr/lib/systemd/system/
+systemctl daemon-reload
+systemctl start dashing-icinga2.service
+systemctl status dashing-icinga2.service
+```
+
+#### Debian
+```bash
+cp tools/systemd/dashing-icinga2.service /lib/systemd/system/
 systemctl daemon-reload
 systemctl start dashing-icinga2.service
 systemctl status dashing-icinga2.service

--- a/tools/logrotate/dashing-icinga2
+++ b/tools/logrotate/dashing-icinga2
@@ -1,4 +1,4 @@
-/usr/share/icinga2-dashing/log/thin.log {
+/usr/share/dashing-icinga2/log/thin.log {
         daily
         rotate 7
         compress


### PR DESCRIPTION
path fixed
should point to /usr/share/dashing-icinga2/log/thin.log instead of /usr/share/icinga2-dashing/log/thin.log