### PR TITLE
Add option to show only hard state problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,12 @@ vim config/icinga2.local.json
   },
   "icingaweb2": {
     "url": "http://localhost/icingaweb2"
-  }
+  },
+  "suppress_flicker": false
 }
 ```
+
+The `suppress_flicker`-option lets dashing ignore warnings and criticals until they become a hard state warning or hard state critical (off by default).
 
 If you prefer to use client certificates, set the `pki_path` attribute. The Icinga 2
 job expects the certificate file names based on the local FQDN e.g. `pki/icinga2-master1.localdomain.crt`.
@@ -230,7 +233,8 @@ explicitly.
   },
   "icingaweb2": {
     "url": "http://localhost/icingaweb2"
-  }
+  },
+  "suppress_flicker": false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,8 @@ vim config/icinga2.local.json
 }
 ```
 
-The `show_only_hard_state_problems`-option lets dashing ignore warnings and criticals until they become a hard state warning or hard state critical (off by default).
+The `show_only_hard_state_problems` option ignores NOT-OK states until they
+reach a hard NOT-OK state (off by default).
 
 If you prefer to use client certificates, set the `pki_path` attribute. The Icinga 2
 job expects the certificate file names based on the local FQDN e.g. `pki/icinga2-master1.localdomain.crt`.
@@ -234,7 +235,9 @@ explicitly.
   "icingaweb2": {
     "url": "http://localhost/icingaweb2"
   },
-  "show_only_hard_state_problems": false
+  "dashboard": {
+    "show_only_hard_state_problems": false
+  }
 }
 ```
 
@@ -256,6 +259,7 @@ ICINGA2\_API\_PASSWORD   | **Optional.** Required for basic auth as password.
 ICINGA2\_API\_CERT\_PATH | **Optional.** Client certificate path.
 ICINGA2\_API\_NODENAME   | **Optional.** If client certificates do not match the host name, override it.
 ICINGAWEB2\_URL          | **Optional.** Set the Icinga Web 2 Url. Defaults to `http://localhost/icingaweb2`.
+DASHBOARD_SHOW_ONLY_HARD_STATE_PROBLEMS | **Optional.** Set `show_only_hard_state_problems` configuration option, toggle with `0|1`.
 
 > **Note**
 >

--- a/README.md
+++ b/README.md
@@ -209,11 +209,11 @@ vim config/icinga2.local.json
   "icingaweb2": {
     "url": "http://localhost/icingaweb2"
   },
-  "suppress_flicker": false
+  "show_only_hard_state_problems": false
 }
 ```
 
-The `suppress_flicker`-option lets dashing ignore warnings and criticals until they become a hard state warning or hard state critical (off by default).
+The `show_only_hard_state_problems`-option lets dashing ignore warnings and criticals until they become a hard state warning or hard state critical (off by default).
 
 If you prefer to use client certificates, set the `pki_path` attribute. The Icinga 2
 job expects the certificate file names based on the local FQDN e.g. `pki/icinga2-master1.localdomain.crt`.
@@ -234,7 +234,7 @@ explicitly.
   "icingaweb2": {
     "url": "http://localhost/icingaweb2"
   },
-  "suppress_flicker": false
+  "show_only_hard_state_problems": false
 }
 ```
 

--- a/config/icinga2.json
+++ b/config/icinga2.json
@@ -10,5 +10,7 @@
   "icingaweb2": {
     "url": "http://localhost/icingaweb2"
   },
-  "show_only_hard_state_problems": false
+  "dashboard": {
+    "show_only_hard_state_problems": false
+  }
 }

--- a/config/icinga2.json
+++ b/config/icinga2.json
@@ -10,5 +10,5 @@
   "icingaweb2": {
     "url": "http://localhost/icingaweb2"
   },
-  "suppress_flicker": false
+  "show_only_hard_state_problems": false
 }

--- a/config/icinga2.json
+++ b/config/icinga2.json
@@ -9,5 +9,6 @@
   },
   "icingaweb2": {
     "url": "http://localhost/icingaweb2"
-  }
+  },
+  "suppress_flicker": false
 }

--- a/lib/icinga2.rb
+++ b/lib/icinga2.rb
@@ -154,7 +154,7 @@ class Icinga2
             @password = @config["icinga2"]["api"]["password"]
             @pkiPath = @config["icinga2"]["api"]["pki_path"]
             @nodeName = @config['icinga2']['api']['node_name']
-            @suppressFlicker = @config['suppress_flicker']
+            @suppressFlicker = @config['show_only_hard_state_problems']
           end
         end
 

--- a/lib/icinga2.rb
+++ b/lib/icinga2.rb
@@ -154,6 +154,7 @@ class Icinga2
             @password = @config["icinga2"]["api"]["password"]
             @pkiPath = @config["icinga2"]["api"]["pki_path"]
             @nodeName = @config['icinga2']['api']['node_name']
+            @suppressFlicker = @config['suppress_flicker']
           end
         end
 
@@ -170,6 +171,7 @@ class Icinga2
         @password = "icinga2ondashingr0xx"
         @pkiPath = "pki/"
         @nodeName = nil
+        @suppressFlicker = false
 
         # external attribute
         @icingaweb2_url = 'http://localhost/icingaweb2'
@@ -418,8 +420,14 @@ class Icinga2
           next
         end
 
-        if (compStates.include?(d["state"]) && d["downtime_depth"] == 0 && d["acknowledgement"] == 0)
-          problems = problems + 1
+        if @suppressFlicker
+          if (compStates.include?(d["state"]) && d["downtime_depth"] == 0 && d["acknowledgement"] == 0 && d['last_hard_state'] != 0.0)
+            problems = problems + 1
+          end
+        else
+          if (compStates.include?(d["state"]) && d["downtime_depth"] == 0 && d["acknowledgement"] == 0)
+            problems = problems + 1
+          end
         end
       end
     end
@@ -698,8 +706,16 @@ class Icinga2
 
     ## Objects data
     # fetch the minimal attributes for problem calculation
-    all_hosts_data = getHostObjects([ "name", "state", "acknowledgement", "downtime_depth", "last_check" ], nil, nil)
-    all_services_data = getServiceObjects([ "name", "state", "acknowledgement", "downtime_depth", "last_check" ], nil, [ "host.name", "host.state", "host.acknowledgement", "host.downtime_depth", "host.last_check" ])
+    all_hosts_data = nil
+    all_services_data = nil
+
+    if @suppressFlicker
+      all_hosts_data = getHostObjects([ "name", "state", "acknowledgement", "downtime_depth", "last_check", "last_hard_state" ], nil, nil)
+      all_services_data = getServiceObjects([ "name", "state", "acknowledgement", "downtime_depth", "last_check", "last_hard_state" ], nil, [ "host.name", "host.state", "host.acknowledgement", "host.downtime_depth", "host.last_check" ])
+    else
+      all_hosts_data = getHostObjects([ "name", "state", "acknowledgement", "downtime_depth", "last_check" ], nil, nil)
+      all_services_data = getServiceObjects([ "name", "state", "acknowledgement", "downtime_depth", "last_check" ], nil, [ "host.name", "host.state", "host.acknowledgement", "host.downtime_depth", "host.last_check" ])
+    end
 
     unless(all_hosts_data.nil?)
       @host_count_all = all_hosts_data.size


### PR DESCRIPTION
In my company we have dashing on a wall screen to show the current icinga status. However, flickering warnings and criticals became annoying and we did not find a way to make icinga not warn us until they became hard state problems. (ref question asked here: https://monitoring-portal.org/t/make-icinga-hold-back-warning-or-critical-before-reaching-hard-state/6034)

The solution was to add some logic to dashing that checks if a service or host problem is a warning or critical AND that the last hard state is not-ok, that is we have a hard state warning or critical. 

I imagine this could be useful for others too :) 