### PR TITLE
Add timezone to clock widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,23 @@ Example:
     </li>
 ```
 
+
+#### Clock
+
+Show the time in a specific timezone. Enter the timezone as found in `/usr/share/zoneinfo` on Linux.
+
+Example:
+
+```html
+    <li data-row="1" data-col="1" data-sizex="1" data-sizey="1">
+      <div data-view="Clock" data-title="UTC" data-timezone="UTC"></div>
+    </li>
+    <li data-row="1" data-col="2" data-sizex="1" data-sizey="1">
+      <div data-view="Clock" data-title="New York" data-timezone="America/New_York"></div>
+    </li>
+```
+
+
 ### References
 
 https://www.icinga.com/2016/01/28/awesome-dashing-dashboards-with-icinga-2/

--- a/widgets/clock/clock.coffee
+++ b/widgets/clock/clock.coffee
@@ -5,8 +5,19 @@ class Dashing.Clock extends Dashing.Widget
 
   startTime: =>
     zone = @get('timezone')
-    optionsDate = { timeZone: zone, weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' };
-    optionsTime = { timeZone: zone, hour: '2-digit', minute: '2-digit'};
+    optionsDate = {
+      timeZone: zone,
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    };
+    optionsTime = {
+      timeZone: zone,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    };
 
     date = new Date().toLocaleDateString('en-US', optionsDate);
     time = new Date().toLocaleTimeString('en-US', optionsTime);

--- a/widgets/clock/clock.coffee
+++ b/widgets/clock/clock.coffee
@@ -4,15 +4,13 @@ class Dashing.Clock extends Dashing.Widget
     setInterval(@startTime, 500)
 
   startTime: =>
-    today = new Date()
+    zone = @get('timezone')
+    optionsDate = { timeZone: zone, weekday: 'short', year: 'numeric', month: 'short', day: 'numeric' };
+    optionsTime = { timeZone: zone, hour: '2-digit', minute: '2-digit'};
 
-    h = today.getHours()
-    m = today.getMinutes()
-    s = today.getSeconds()
-    m = @formatTime(m)
-    s = @formatTime(s)
-    @set('time', h + ":" + m + ":" + s)
-    @set('date', today.toDateString())
+    date = new Date().toLocaleDateString('en-US', optionsDate);
+    time = new Date().toLocaleTimeString('en-US', optionsTime);
 
-  formatTime: (i) ->
-    if i < 10 then "0" + i else i
+    @set('time', time)
+    @set('date', date)
+    @set('title', @get('title'))

--- a/widgets/clock/clock.html
+++ b/widgets/clock/clock.html
@@ -1,3 +1,3 @@
 <h1 data-bind="title"></h1>
 <h3 data-bind="date"></h3>
-<h2 style="font-size:4em;" data-bind="time"></h2>
+<h2 data-bind="time"></h2>

--- a/widgets/clock/clock.html
+++ b/widgets/clock/clock.html
@@ -1,2 +1,3 @@
-<h1 data-bind="date"></h1>
-<h2 data-bind="time"></h2>
+<h1 data-bind="title"></h1>
+<h3 data-bind="date"></h3>
+<h2 style="font-size:4em;" data-bind="time"></h2>


### PR DESCRIPTION
My company has servers across the world and we would like to see the time at these places. The clock widget could easily be extended to show the time in a specific timezone using zones defined in the tz database.

Tested in Chrome and Firefox on Windows and Linux. 