### PR TITLE
Fix version regexp

### DIFF
--- a/lib/icinga2.rb
+++ b/lib/icinga2.rb
@@ -600,7 +600,7 @@ class Icinga2
     version_map = version.split('-', 2)
     version_str = version_map[0]
     # strip v2.4.10 (default) and r2.4.10 (Debian)
-    version_str = version_str.scan(/^[vr]+(.*)/).last.first
+    version_str = version_str.scan(/^[vr]?(.*)/).last.first
 
     if version_map.size() > 1
       @version_revision = version_map[1]

--- a/lib/icinga2.rb
+++ b/lib/icinga2.rb
@@ -530,6 +530,11 @@ class Icinga2
         next
       end
 
+      #Skip services in a scheduled downtime
+      if (service["attrs"]["downtime_depth"] > 0)
+        next
+      end
+
       service_problems[service] = getServiceSeverity(service)
     end
 


### PR DESCRIPTION
Since Icinga2 version 2.11 the version string in API /v1/status/IcingaApplication is without "v" prefix.

The scheduled downtimes are not reported in the "Unhandled Services" so I have filtered them out of the "Problems" section.