### PR TITLE
Use Chartjs update() and rebuild chart only when necessary

### DIFF
--- a/widgets/chartjs/chartjs.coffee
+++ b/widgets/chartjs/chartjs.coffee
@@ -102,12 +102,18 @@ class Dashing.Chartjs extends Dashing.Widget
         return
 
   circularChart: (id, { type, labels, colors, datasets, options }) ->
-    data = @merge labels: labels, datasets: [@merge data: datasets, @colors(colors)]
-    new Chart(document.getElementById(id), { type: type, data: data }, options)
+    @ensureChartExists()
+    @chart.data = @merge labels: labels, datasets: [@merge data: datasets, @colors(colors)]
+    @chart.update()
 
   linearChart: (id, { type, labels, header, colors, datasets, options }) ->
-    data = @merge labels: labels, datasets: [@merge(@colors(colors), label: header, data: datasets)]
-    new Chart(document.getElementById(id), { type: type, data: data }, options)
+    @ensureChartExists()
+    @chart.data = @merge labels: labels, datasets: [@merge(@colors(colors), label: header, data: datasets)]
+    @chart.update()
+
+  ensureChartExists: () ->
+    if typeof @chart == "undefined"
+      @chart = new Chart(document.getElementById(@id), { type: @type, data: @merge labels: @labels, datasets: [@merge data: @datasets, @colors(@colorNames)] }, @options)
 
   merge: (xs...) =>
     if xs?.length > 0


### PR DESCRIPTION
This fixes https://github.com/dnsmichi/dashing-icinga2/issues/93

Some of the arguments to `circularChart` and `linearChart` are now unused and should maybe also be dropped.