### PR TITLE
Scrolling of crammed widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ The following attributes are important:
 * `data-title` defines the widget's title on top
 * `data-min` and `data-max` are widget specific in this example. They are referenced inside the Coffee script file inside the widget code.
 * `style` can be used to specify certain CSS to make the widget look more beautiful if not already.
+* `class=scrollable` allows for scrolling of crammed widgets. Works for most widgets but is mostly meant to be used with `List` and `Simplelist`.
 
 ### Dashboard Widgets
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -268,3 +268,16 @@ h3 {
 .clearfix:after { clear: both; }
 .clearfix { zoom: 1; }
 
+// ----------------------------------------------------------------------------
+// Adding scrolling functionality to widgets for all browsers
+// ----------------------------------------------------------------------------
+.scrollable {
+  overflow: hidden;
+}
+
+.scrollable .content {
+  height: 100%;
+  overflow-y: scroll;
+  margin-right: -50px;
+  padding-right: 50px;
+}

--- a/dashboards/icinga2.erb
+++ b/dashboards/icinga2.erb
@@ -135,7 +135,7 @@ $(function() {
 
     <!-- Takes two rows for all service problems by severity -->
     <li data-row="1" data-col="5" data-sizex="1" data-sizey="3">
-      <div data-id="icinga-severity" data-view="List" data-unordered="true" data-title="Problems"></div>
+      <div class="scrollable" data-id="icinga-severity" data-view="List" data-unordered="true" data-title="Problems"></div>
     </li>
 
     <!-- Icinga Web 2 iFrame. getIcingaWeb2Url() is defined in config.ru and reads from config/icinga2*.json -->


### PR DESCRIPTION
7 lines of CSS in `application.scss` to allow the scrolling of widgets when they are crammed with entries. Especially useful for `List` and `Simplelist` widgets.

The changes do not affect the appearance of Dashing Icinga2. The scroll bars get pushed out of rendered areas by CSS for every browser and a widget's `title` and `moreInfo` sections stay where they are while scrolling `content`.

The functionality is enabled on a per-widget basis by adding the `class=scrollable` tag within their declarations in the respective `dashboard.erb` files.