### PR TITLE
Added new Edge to supported browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Supported browsers and clients:
 
 * Linux, Unix, \*Pi
 * Chrome, Firefox, Safari
+* "new" Edge [v79 and above]
 
-**Windows with IE and Edge is not supported since SSE (Server Sent Events) are not implemented.**
+**Windows with IE and old Edge (without Chromium) is not supported since SSE (Server Sent Events) are not implemented.**
 
 For more details please read [#47](https://github.com/dnsmichi/dashing-icinga2/issues/47#issuecomment-374166481)
 and [#62](https://github.com/dnsmichi/dashing-icinga2/issues/62).


### PR DESCRIPTION
Microsoft Edge is based on Chromium from now on and implements SSE's.

Tested compatibility on both, our heavily differing implementation as well as on the demo provided by this repository.