### PR TITLE
no-services-for-down-hosts-show-display-name-for-services-and-hosts

### DIFF
--- a/dashboards/icinga2.erb
+++ b/dashboards/icinga2.erb
@@ -5,7 +5,7 @@ $(function() {
   Dashing.widget_base_dimensions = [300,300]
   //Experimental: widget size based on window size.
   //Dashing.widget_base_dimensions = [$( window ).width()/5, $( window ).height()/2.2];
-  Dashing.numColumns = 5
+  Dashing.numColumns = 4
 });
 </script>
 
@@ -18,81 +18,10 @@ $(function() {
     </li>
 
     <li data-row="1" data-col="2" data-sizex="1" data-sizey="1">
-      <div
-        data-id="doughnut-pie-hosts"
-        data-view="Chartjs"
-        data-type="doughnut"
-        data-title="Hosts"
-        data-labels="Up,Down"
-        data-colornames="green,red"
-        data-datasets="20,13"
-        data-height="300"
-        data-width="300"
-      ></div>
-    </li>
-    <li data-row="1" data-col="3" data-sizex="1" data-sizey="1">
-      <div
-        data-id="doughnut-pie-services"
-        data-view="Chartjs"
-        data-type="doughnut"
-        data-title="Services"
-        data-labels="OK,Warning,Critical,Unknown"
-        data-colornames="green,yellow,red,purple"
-        data-datasets="20,13,12,0"
-        data-height="300"
-        data-width="300"
-      ></div>
-    </li>
-    <li data-row="1" data-col="4" data-sizex="1" data-sizey="1">
-      <div
-        data-id="bar-chart-endpoints"
-        data-view="Chartjs"
-        data-type="bar"
-        data-header="Endpoints"
-        data-title="Endpoints"
-        data-labels="Connected,Not Connected"
-        data-colornames="green,red"
-        data-datasets="42,404"
-        data-height="300"
-        data-width="300"
-      ></div>
-    </li>
-
-    <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
       <div data-id="icinga-stats" data-view="List" data-unordered="true" data-title="Statistics"></div>
     </li>
 
-    <li data-row="2" data-col="2" data-sizex="1" data-sizey="1">
-      <div
-        data-id="bar-chart-checks"
-        data-view="Chartjs"
-        data-type="horizontalBar"
-        data-header="Active Checks"
-        data-title="Active Checks"
-        data-labels="Hosts/min,Services/min"
-        data-colornames="aqua,lime"
-        data-datasets="42,404"
-        data-height="300"
-        data-width="300"
-      ></div>
-    </li>
-
-    <li data-row="2" data-col="3" data-sizex="1" data-sizey="1">
-      <div
-        data-id="bar-chart-downtimes"
-        data-view="Chartjs"
-        data-type="horizontalBar"
-        data-header="Downtimes"
-        data-title="Downtimes"
-        data-labels="Hosts,Services"
-        data-colornames="blue,green"
-        data-datasets="42,404"
-        data-height="300"
-        data-width="300"
-      ></div>
-    </li>
-
-    <li data-row="2" data-col="4" data-sizex="1" data-sizey="1">
+    <!-- <li data-row="1" data-col="3" data-sizex="1" data-sizey="1">
       <div
         data-id="bar-chart-acks"
         data-view="Chartjs"
@@ -105,7 +34,101 @@ $(function() {
         data-height="300"
         data-width="300"
       ></div>
+    </li> -->
+
+
+    <!-- <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
+      <div
+        data-id="doughnut-pie-hosts"
+        data-view="Chartjs"
+        data-type="doughnut"
+        data-title="Hosts"
+        data-labels="Up,Down"
+        data-colornames="green,red"
+        data-datasets="20,13"
+        data-height="300"
+        data-width="300"
+      ></div>
     </li>
+    <li data-row="2" data-col="2" data-sizex="1" data-sizey="1">
+      <div
+        data-id="doughnut-pie-services"
+        data-view="Chartjs"
+        data-type="doughnut"
+        data-title="Services"
+        data-labels="OK,Warning,Critical,Unknown"
+        data-colornames="green,yellow,red,purple"
+        data-datasets="20,13,12,0"
+        data-height="300"
+        data-width="300"
+      ></div>
+    </li> -->
+
+    <!-- Service and Hosts wie im alten Dashboard -->
+    <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
+      <div
+           data-id="icinga-host-meter"
+           data-view="Meter"
+           data-title="Host Problems"
+           data-min="0"
+           data-max="100"
+      ></div>
+    </li>
+    <li data-row="2" data-col="2" data-sizex="1" data-sizey="1">
+      <div 
+           data-id="icinga-service-meter"
+           data-view="Meter"
+           data-title="Service Problems"
+           data-min="0" data-max="100"
+      ></div>
+    </li>
+
+    <!-- <li data-row="2" data-col="3" data-sizex="1" data-sizey="1">
+      <div
+        data-id="bar-chart-downtimes"
+        data-view="Chartjs"
+        data-type="horizontalBar"
+        data-header="Downtimes"
+        data-title="Downtimes"
+        data-labels="Hosts,Services"
+        data-colornames="blue,green"
+        data-datasets="42,404"
+        data-height="300"
+        data-width="300"
+      ></div>
+    </li> -->
+
+    <!-- <li data-row="2" data-col="3" data-sizex="1" data-sizey="1">
+      <div
+        data-id="bar-chart-endpoints"
+        data-view="Chartjs"
+        data-type="bar"
+        data-header="Endpoints"
+        data-title="Endpoints"
+        data-labels="Connected,Not Connected"
+        data-colornames="green,red"
+        data-datasets="42,404"
+        data-height="300"
+        data-width="300"
+      ></div>
+    </li> -->
+
+    
+
+    <!-- <li data-row="2" data-col="1" data-sizex="1" data-sizey="1">
+      <div
+        data-id="bar-chart-checks"
+        data-view="Chartjs"
+        data-type="horizontalBar"
+        data-header="Active Checks"
+        data-title="Active Checks"
+        data-labels="Hosts/min,Services/min"
+        data-colornames="aqua,lime"
+        data-datasets="42,404"
+        data-height="300"
+        data-width="300"
+      ></div>
+    </li> -->
 
     <!-- Problems -->
     <!--
@@ -134,17 +157,17 @@ $(function() {
     -->
 
     <!-- Takes two rows for all service problems by severity -->
-    <li data-row="1" data-col="5" data-sizex="1" data-sizey="3">
-      <div class="scrollable" data-id="icinga-severity" data-view="List" data-unordered="true" data-title="Problems"></div>
+    <li data-row="1" data-col="3" data-sizex="2" data-sizey="2">
+      <div data-id="icinga-severity" data-view="List" data-unordered="true" data-title="Service and Host Problems"></div>
     </li>
 
     <!-- Icinga Web 2 iFrame. getIcingaWeb2Url() is defined in config.ru and reads from config/icinga2*.json -->
-    <li data-row="3" data-col="1" data-sizex="2" data-sizey="2">
+    <!-- <li data-row="3" data-col="1" data-sizex="2" data-sizey="2">
       <div data-id="iframe" data-view="Iframe" data-title="Icinga Web Host Problems" data-url="<%=getIcingaWeb2Url()%>/monitoring/list/hosts?host_problem=1&sort=host_severity&showFullscreen&showCompact"></div>
     </li>
     <li data-row="3" data-col="3" data-sizex="2" data-sizey="2">
       <div data-id="iframe" data-view="Iframe" data-title="Icinga Web Service Problems" data-url="<%=getIcingaWeb2Url()%>/monitoring/list/services?service_problem=1&sort=service_severity&dir=desc&showFullscreen&showCompact"></div>
-    </li>
+    </li>-->
   </ul>
 
 </div>

--- a/jobs/icinga2.rb
+++ b/jobs/icinga2.rb
@@ -26,7 +26,7 @@ SCHEDULER.every '10s', :first_in => 0 do |job|
   # run data provider
   icinga.run
 
-  puts "App Info: " + icinga.app_data.to_s + " Version: " + icinga.version
+  #puts "App Info: " + icinga.app_data.to_s + " Version: " + icinga.version
   #puts "CIB Info: " + icinga.cib_data.to_s
 
   # meter widget
@@ -36,7 +36,7 @@ SCHEDULER.every '10s', :first_in => 0 do |job|
   service_meter = icinga.service_count_problems.to_f
   service_meter_max = icinga.service_count_all
 
-  puts "Meter widget: Hosts " + host_meter.to_s + "/" + host_meter_max.to_s + " Services " + service_meter.to_s + "/" + service_meter_max.to_s
+  #puts "Meter widget: Hosts " + host_meter.to_s + "/" + host_meter_max.to_s + " Services " + service_meter.to_s + "/" + service_meter_max.to_s
 
   # icinga stats
   icinga_stats = [
@@ -53,12 +53,23 @@ SCHEDULER.every '10s', :first_in => 0 do |job|
   #  icinga_stats.push( { "label" => name, "value" => "%0.2f" % value } )
   #end
 
-  puts "Stats: " + icinga_stats.to_s
+  #puts "Stats: " + icinga_stats.to_s
 
   ### Events
+  send_event('icinga-host-meter', {
+   value: host_meter,
+   max:   host_meter_max,
+   moreinfo: "Total hosts: " + host_meter_max.to_s,
+   color: 'blue' })
+
+  send_event('icinga-service-meter', {
+   value: service_meter,
+   max:   service_meter_max,
+   moreinfo: "Total services: " + service_meter_max.to_s,
+   color: 'blue' })
 
   send_event('icinga-stats', {
-   title: icinga.version,
+   title: "Icinga " + icinga.version,
    items: icinga_stats,
    moreinfo: "Avg latency: " + icinga.avg_latency.to_s + "s",
    color: 'blue' })
@@ -147,7 +158,7 @@ SCHEDULER.every '10s', :first_in => 0 do |job|
     order.index(a['state']) <=> order.index(b['state'])
   end
 
-  puts "Severity: " + result.to_s
+  #puts "Severity: " + result.to_s
 
   send_event('icinga-severity', {
    items: result,


### PR DESCRIPTION
For our purpose we had to make some optimizations:

1. Show display name for hosts and services.
2. If a host is down only the display name of the host is listetd, but no service.
3. If a host or a service has a scheduled downtime, it is ignored.

Maybe some others could benefit from our changes as well.